### PR TITLE
[WIP] Remove test.log

### DIFF
--- a/vars/elifeSpectrum.groovy
+++ b/vars/elifeSpectrum.groovy
@@ -73,6 +73,7 @@ def call(Map parameters) {
                     def testLogArtifact = "${env.BUILD_TAG}.${environmentName}.log"
                     sh "cp ${env.SPECTRUM_PREFIX}build/test.log ${testLogArtifact}"
                     archive testLogArtifact
+                    sh "rm ${env.SPECTRUM_PREFIX}build/test.log"
                 }
 
                 elifeVerifyJunitXml testXmlArtifact

--- a/vars/elifeSpectrum.groovy
+++ b/vars/elifeSpectrum.groovy
@@ -67,6 +67,7 @@ def call(Map parameters) {
                     sh "cp ${env.SPECTRUM_PREFIX}build/junit.xml ${testXmlArtifact}"
                     echo "Found: ${testXmlArtifact}"
                     step([$class: "JUnitResultArchiver", testResults: testXmlArtifact])
+                    sh "rm ${env.SPECTRUM_PREFIX}build/junit.xml"
                 }
 
                 if (fileExists("${env.SPECTRUM_PREFIX}build/test.log")) {


### PR DESCRIPTION
https://alfred.elifesciences.org/job/test-journal-cms/513/ seemed to pick up the end2end log file from https://alfred.elifesciences.org/job/test-journal-cms/512/, even though it didn't get as far as running it.

Think the same applies to `junit.xml`? (There's usage of `JUnitResultArchiver` elsewhere too.)

/cc @nlisgo