### PR TITLE
changed dockerComposeRun to not capture output

### DIFF
--- a/vars/dockerComposeRun.groovy
+++ b/vars/dockerComposeRun.groovy
@@ -3,15 +3,12 @@ import DockerCompose
 def call(service, command, tag='latest')
 {
     try {
-        return sh(
-            script: DockerCompose
-                .command('run', ['docker-compose.yml', 'docker-compose.ci.yml'])
-                .withEnvironment('IMAGE_TAG', tag)
-                .withArgument(service)
-                .withArgument(command)
-                .toString(),
-            returnStdout: true
-        )
+        sh DockerCompose
+            .command('run', ['docker-compose.yml', 'docker-compose.ci.yml'])
+            .withEnvironment('IMAGE_TAG', tag)
+            .withArgument(service)
+            .withArgument(command)
+            .toString()
     } finally {
         sh DockerCompose
             .command('down', ['docker-compose.yml', 'docker-compose.ci.yml'])

--- a/vars/dockerComposeRun.txt
+++ b/vars/dockerComposeRun.txt
@@ -1,5 +1,3 @@
 Runs `command` using the `docker-compose` `service`, cleaning up after the run.
 
-Returns the standard output of the command execution.
-
 Strongly suggested to specify the `tag` that will be passed as `IMAGE_TAG` to the `docker-compose.ci.yml`.


### PR DESCRIPTION
Changed `dockerComposeRun` to capture the output (`dockerComposeRunAndCaptureOutput` should be used instead in that case)

(After https://github.com/elifesciences/sciencebeam-alignment/pull/10 has been merged)