### PR TITLE
fix: buildArgs always equal null

### DIFF
--- a/vars/dockerBuild.groovy
+++ b/vars/dockerBuild.groovy
@@ -6,8 +6,8 @@ def call(project, tag='latest', dockerfileSuffix = null, organization='elifescie
         dockerfile = "${dockerfile}.${dockerfileSuffix}"
     }
     def buildArgsOption = ''
-    for (def argName in buildArgs) {
-        buildArgsOption += " --build-arg ${argName}=${buildArgs[argName]}"
+    for (argName in buildArgs) {
+        buildArgsOption += " --build-arg ${argName.key}=${argName.value}"
     }
     sh "docker build --pull -f ${dockerfile} -t ${imageName}:${tag} .${buildArgsOption}"
     //return new DockerImage(this)


### PR DESCRIPTION
Looking at https://www.baeldung.com/groovy-map-iterating...

I 'think' the loop needs adjusting to use explicit 'key' and 'value' properties to get what we need. Not sure how to test this locally though so putting in another 'blind' PR.