### PR TITLE
fix: jenkins pipelines fail waiting package publish to packagist

### DIFF
--- a/vars/elifeWaitPackagist.groovy
+++ b/vars/elifeWaitPackagist.groovy
@@ -1,3 +1,3 @@
 def call(packageName, revision) {
-    sh "timeout 60s /usr/local/jenkins-scripts/wait_packagist.sh ${packageName} ${revision}"
+    sh "timeout 5m /usr/local/jenkins-scripts/wait_packagist.sh ${packageName} ${revision}"
 }

--- a/vars/elifeWaitPackagist.groovy
+++ b/vars/elifeWaitPackagist.groovy
@@ -1,3 +1,6 @@
 def call(packageName, revision) {
+    // "The search index is updated every five minutes. 
+    // It will index (or reindex) any package that has been crawled since the last time the search indexer ran."
+    // - https://packagist.org/about
     sh "timeout 5m /usr/local/jenkins-scripts/wait_packagist.sh ${packageName} ${revision}"
 }


### PR DESCRIPTION
Jenkins pipelines to update [error pages](https://alfred.elifesciences.org/job/dependencies/job/dependencies-error-pages-update-patterns-php/) and [journal](https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/) to the latest version of pattern-library have been failing for a while. 

The issue is that the pipeline times out waiting for the package to become available on [packagist](https://packagist.org/packages/elife/patterns). According to packagist's docs it can take them up to 5 minutes to re-index after an update, hence it seems sensible to increase the timeout from 1 minute to 5 minutes.

This fixes elifesciences/issues#6058