### PR TITLE
fix: pattern-library npm package is empty when published

### DIFF
--- a/vars/elifeNpmRelease.groovy
+++ b/vars/elifeNpmRelease.groovy
@@ -59,6 +59,7 @@ def call() {
     
     withCredentials([string(credentialsId: 'npm-credentials', variable: 'NPM_TOKEN')]) {
         command "echo \"//registry.npmjs.org/:_authToken=\${NPM_TOKEN}\" > .npmrc"
+        command "npm run prepare"
         command "npm publish --access public"
         assert retval == 0 : "failed to publish package '${pkgname}'"
     }


### PR DESCRIPTION
Issue is caused by the `npm` version on the jenkins node does not support the prepare command, hence the css is not being bundled prior to an `npm publish` call. I've updated the CI script to explicitly call `prepare` before publishing which resolves the above issue.

This fixes elifesciences/issues#6076