### PR TITLE
elifePipeline, shifts notify maintainers logic to it's own block.

### DIFF
--- a/vars/elifePipeline.txt
+++ b/vars/elifePipeline.txt
@@ -1,8 +1,11 @@
-Should be used as the top level construct for pipeline stages. Accepts a block and wraps it with timestamps and colors to make the build output more understandable.
+Should be used as the top level construct for pipeline stages. Accepts a block and wraps it with timestamps and colors 
+to make the build output more understandable.
 
-If a `maintainers.txt` file is present in the repository, build failures will be sent to them through email or Slack notifications:
+If a `maintainers.txt` file is present in the repository, build failures will be sent to them through email or 
+Slack notifications:
 
-- `foo@example.com`
+- `my-githubalias`
+- `my-email@example.com`
 - `#my-slack-channel`
 
 An additional `timeoutInMinutes` can be passed to override the default 2 hours maximum running time.


### PR DESCRIPTION
it's preventing elifePipeline from being used outside of Jenkinsfiles.