### PR TITLE
elifeUpdateProjectByEnv, failures in 'daily-security-update' are ignored

### DIFF
--- a/vars/elifeUpdateProjectByEnv.groovy
+++ b/vars/elifeUpdateProjectByEnv.groovy
@@ -1,7 +1,12 @@
 def call(String project_name, String envlist) {
     elifeProjectByEnvByNode(project_name, envlist, { project, env, node ->
         def stackname = "${project}--${env}"
-        builderCmdNode(stackname, node, "sudo /usr/local/bin/daily-security-update");
+        try {
+            builderCmdNode(stackname, node, "sudo /usr/local/bin/daily-security-update");
+        } catch (err) {
+            println("call to 'daily-security-update' script failed: " + err.toString())
+            println("ignoring and restarting instance.")
+        }
         builderRunTask("aws.ec2.stop_node", stackname, node as String)
         builderStart(stackname)
         builderCmdNode(stackname, node, "sudo /usr/local/bin/daily-system-update");


### PR DESCRIPTION
the error is printed to stdout, the node is restarted and highstate is run. if there is a node-breaking error then it should hopefully cause highstate to fail.