### PR TITLE
builderCmdNode, concurrency set to 'serial'.

### DIFF
--- a/vars/builderCmdNode.groovy
+++ b/vars/builderCmdNode.groovy
@@ -3,7 +3,11 @@ def call(String stackname, Integer node, String cmd, folder=null, captureOutput=
         cmd = "cd ${folder} && " + cmd;
     }
     cmd = _escapeCmd(cmd)
-    def additionalBuilderOptions = ",node=${node}"
+    // lsh@2023-03-22: concurrency set to 'serial' as default is 'parallel'.
+    // stacktraces for failed commands when run in parallel are longer as the parallel executor
+    // prints a stacktrace for any jobs that fail, before failing itself.
+    // since this command specifically targets individual nodes there is no need for parallelism.
+    def additionalBuilderOptions = ",concurrency=serial,node=${node},"
     if (captureOutput) {
         additionalBuilderOptions = additionalBuilderOptions + ",clean_output=1"
     }


### PR DESCRIPTION
default is 'parallel' which has longer stacktraces. 'parallel' is only when multiple nodes are involved.